### PR TITLE
Fix verbose stream output (Issue #3)

### DIFF
--- a/PoshRSJob/Private/WriteStream.ps1
+++ b/PoshRSJob/Private/WriteStream.ps1
@@ -5,6 +5,7 @@ Function WriteStream {
         [Object]$IndividualJob
     )
     Begin {
+        $VerbosePreference = 'Continue'
         $Streams = "Verbose","Warning","Error","Output","Debug","Information"
     }
 


### PR DESCRIPTION
Since commit eeb86afd1b8ecc9b8ce1844141b96d50f592410c verbose output does not work anymore.


Changes proposed in this pull request:
 - Set **$VerbosePreference** to *Continue* in *WriteStream.ps1* function for verbose stream output
- Fixes #3 

